### PR TITLE
Change resize handlers

### DIFF
--- a/nebgl.js
+++ b/nebgl.js
@@ -179,10 +179,21 @@ var NebGL = {
 		}
 	},
 	
-	setResizeHandler: function(context, handler) {
-		if(context) {
-			context._resizehandler = handler;
+	registerResizeHandler: function(context, handler) {
+		if(context && handler) {
+			context._resizehandlers.push(handler);
 		}
+	},
+	
+	deregisterResizeHandler: function(context, handler) {
+		if(context && handler) {
+			var index = context._resizehandlers.indexOf(handler);
+			if(index > -1) {
+				context._resizehandlers.splice(index, 1);
+				return true;
+			}
+		}
+		return false;
 	},
 	
 	// ### extensions ###

--- a/nebgl.js
+++ b/nebgl.js
@@ -70,6 +70,9 @@ var NebGL = {
 		// register context
 		this._registerContext(gl);
 		
+		// init state
+		gl._isfullwindow = config.fullwindow === true;
+		
 		// query extensions
 		var supportedExts = gl.getSupportedExtensions();
 		//gl.supportedExtensions = supportedExts;

--- a/nebgl.js
+++ b/nebgl.js
@@ -23,6 +23,18 @@ var NebGL = {
 		},
 	},
 	
+	_contexts: [],
+	_registerContext: function(context) {
+		if(!context) return;
+		this._contexts.push(context);
+	},
+	_deregisterContext: function(context) {
+		var index = this._contexts.indexOf(context);
+		if(index > -1) {
+			this._contexts.splice(index, 1);
+		}
+	},
+	
 	/** Creates a new WebGL context for the given canvas */
 	createGL: function(canvas, config) {
 		config = config || {};
@@ -55,10 +67,8 @@ var NebGL = {
 			throw "WebGL context creation failed: webgl may be unsupported";
 		}
 		
-		// register fullwindow context
-		if(config.fullwindow) {
-			this._registerFullwindowContext(gl);
-		}
+		// register context
+		this._registerContext(gl);
 		
 		// query extensions
 		var supportedExts = gl.getSupportedExtensions();
@@ -139,17 +149,6 @@ var NebGL = {
 			return _fullscreenEnabled();
 		};
 	})(),
-	
-	_fullwindowContexts: [],
-	_registerFullwindowContext: function(context) {
-		this._fullwindowContexts.push(context);
-	},
-	_deregisterFullwindowContext: function(contxt) {
-		var index = this._fullwindowContexts.indexOf(contxt);
-		if(index > -1) {
-			this._fullwindowContexts.splice(index, 1);
-		}
-	},
 	
 	_processWindowResize: function() {
 		if(NebGL._fullwindowContexts.length > 0) {

--- a/nebgl.js
+++ b/nebgl.js
@@ -151,29 +151,35 @@ var NebGL = {
 	})(),
 	
 	_processWindowResize: function() {
-		if(NebGL._fullwindowContexts.length > 0) {
+		if(NebGL._contexts.length > 0) {
 			var newSize = NebGL.Utils.getWindowSize();
 			
-			// update contexts
-			for(var i = 0; i < NebGL._fullwindowContexts.length; i++) {
-				var ctx = NebGL._fullwindowContexts[i];
-				
+			// call resize callbacks (and process fullwindow contexts)
+			for(var i = 0; i < NebGL._contexts.length; i++) {
+				var ctx = NebGL._contexts[i];
 				var canvas = ctx.canvas;
 				
-				// set canvas size
-				if(canvas) {
-					canvas.setAttribute("width", newSize.x);
-					canvas.setAttribute("height", newSize.y);
-					canvas.style.width = newSize.x + "px";
-					canvas.style.height = newSize.y + "px";
+				if(ctx._isfullwindow === true) {
+					// set canvas size
+					if(canvas) {
+						canvas.setAttribute("width", newSize.x);
+						canvas.setAttribute("height", newSize.y);
+						canvas.style.width = newSize.x + "px";
+						canvas.style.height = newSize.y + "px";
+					}
+					
+					// update gl viewport
+					ctx.viewport(0, 0, newSize.x, newSize.y);
 				}
 				
-				// update gl viewport
-				ctx.viewport(0, 0, newSize.x, newSize.y);
-				
-				// call resize handler
-				if(ctx._resizehandler) {
-					ctx._resizehandler(newSize.x, newSize.y);
+				// call resize handlers
+				if(ctx._resizehandlers) {
+					for(var j = 0; j < ctx._resizehandlers.length; j++) {
+						var handler = ctx._resizehandlers[j];
+						
+						// actually call handler
+						handler(ctx, newSize.x, newSize.y);
+					}
 				}
 			}
 		}

--- a/nebgl.js
+++ b/nebgl.js
@@ -72,6 +72,7 @@ var NebGL = {
 		
 		// init state
 		gl._isfullwindow = config.fullwindow === true;
+		gl._resizehandlers = [];
 		
 		// query extensions
 		var supportedExts = gl.getSupportedExtensions();


### PR DESCRIPTION
This PR changes the following:
- resize handlers are called for any context, not only fullwindow contexts
- multiple resize handlers may be registered (and deregistered) to any context
- resize handler's parameters changed from `(width, height)` to `(context, width, height)`

Consequently, the resize handler registration functions changed from
`setResizeHandler(context, handler)`
to
`registerResizeHandler(context, handler)` and `deregisterResizeHandler(context, handler)`